### PR TITLE
Remove <C-w> key mapping as buf close due to conflict with window key mappings

### DIFF
--- a/lua/custom/mappings.lua
+++ b/lua/custom/mappings.lua
@@ -22,12 +22,6 @@ M.general = {
 
 M.tabufline = {
   n = {
-    ["<C-w>"] = {
-      function()
-        require("nvchad.tabufline").close_buffer()
-      end,
-      "Close buffer",
-    },
     ["<leader>bo"] = {
       function()
         require("nvchad.tabufline").closeOtherBufs()


### PR DESCRIPTION
Use `<leader>x` to close the current buffer as before.