### PR TITLE
Revert "chore(formatter): use shorthand plugin setup syntax"

### DIFF
--- a/lua/custom/configs/formatter.lua
+++ b/lua/custom/configs/formatter.lua
@@ -1,3 +1,5 @@
+local conform = require "conform"
+
 require("conform").setup {
   formatters_by_ft = {
     javascript = { "prettierd" },


### PR DESCRIPTION
Fixes this issue:
![image](https://github.com/anhdau185/nvim-config/assets/37280485/b8149287-3cfe-4c10-9c91-99e78ded97bc)
which was caused by this commit: https://github.com/anhdau185/nvim-config/commit/d8699a1275e921dae681868ef963ac605b7f2ce9