### PR TITLE
Release v2.1

### DIFF
--- a/lua/custom/chadrc.lua
+++ b/lua/custom/chadrc.lua
@@ -33,11 +33,6 @@ M.ui = {
     },
   },
   hl_override = {
-    -- use this highlight group in your iTerm color profile instead
-    -- Cursor = {
-    --   fg = "#1e1e2e",
-    --   bg = "#f9edeb",
-    -- },
     Visual = {
       bg = "#6d5f7c",
     },

--- a/lua/custom/configs/statusline.lua
+++ b/lua/custom/configs/statusline.lua
@@ -29,7 +29,7 @@ local function mode(sep_style)
 
   local m = vim.api.nvim_get_mode().mode
   local sep_r = sep_icons[sep_style].right
-  local current_mode = "%#" .. modes[m][2] .. "#" .. "  " .. modes[m][1] .. gen_extra_space(sep_style)
+  local current_mode = "%#" .. modes[m][2] .. "#" .. " " .. modes[m][1] .. gen_extra_space(sep_style)
   local mode_sep1 = "%#" .. modes[m][2] .. "Sep" .. "#" .. sep_r
   local mode_sep2 = "%#ST_EmptySpace#" .. sep_r
 

--- a/lua/custom/configs/telescope.lua
+++ b/lua/custom/configs/telescope.lua
@@ -10,6 +10,7 @@ local opts = vim.tbl_deep_extend("force", default_opts, {
       height = 0.88,
     },
     wrap_results = true,
+    prompt_prefix = "", -- no prefix icon
   },
 })
 

--- a/lua/custom/init.lua
+++ b/lua/custom/init.lua
@@ -33,6 +33,10 @@ vim.api.nvim_create_autocmd("VimEnter", {
         vim.api.nvim_buf_delete(last_buf, { force = true })
       end
     end)
+
+    vim.schedule(function()
+      vim.cmd "packadd cfilter" -- lazy-load cfilter to enhance quickfix list
+    end)
   end,
 })
 

--- a/lua/custom/plugins.lua
+++ b/lua/custom/plugins.lua
@@ -131,7 +131,8 @@ local plugins = {
   },
   {
     "NvChad/nvim-colorizer.lua",
-    enabled = false,
+    event = "VeryLazy",
+    init = false,
   },
   {
     "NvChad/nvterm",


### PR DESCRIPTION
Commits to be merged in this PR:
- feat(init.lua): lazyload cfilter (enhance the quickfix list by filtering & reducing results)
- feat(statusline): hide vim icon from mode (more concise statusline)
- feat(telescope): hide prompt prefix (cleaner telescope prompt input)
- feat(plugins): re-enable colorizer on VeryLazy event
- chore(chadrc): remove color hint comment for Cursor (manifested in [alacritty color config](https://github.com/anhdau185/dotfiles/blob/main/.config/alacritty/catppuccin-mocha.yml#L12))