### PR TITLE
Updates to gitsigns keymappings and GitSignsChange highlight

### DIFF
--- a/lua/custom/chadrc.lua
+++ b/lua/custom/chadrc.lua
@@ -18,8 +18,10 @@ M.ui = {
       fg = "#8bc2f0",
       bg = "#474656",
     },
+
+    -- for both GitSignsChange and GitSignsChangedelete
     GitSignsChange = {
-      fg = "#f9e2af",
+      fg = "#eed49f",
       bg = "NONE",
     },
 

--- a/lua/custom/init.lua
+++ b/lua/custom/init.lua
@@ -10,10 +10,9 @@ vim.api.nvim_create_autocmd("VimEnter", {
   callback = function(data)
     vim.schedule(function()
       local utils = require "custom.utils"
-      local is_dir = utils.is_dir(data.file)
 
       -- open nvimtree and telescope for file browsing if neovim was opened in a directory
-      if is_dir then
+      if utils.is_dir(data.file) then
         require("nvim-tree.api").tree.open()
         require("telescope.builtin").find_files()
         return

--- a/lua/custom/mappings.lua
+++ b/lua/custom/mappings.lua
@@ -65,6 +65,50 @@ M.telescope = {
   },
 }
 
+M.gitsigns = {
+  n = {
+    -- Navigation through hunks
+    ["<leader>h["] = {
+      function()
+        package.loaded.gitsigns.prev_hunk()
+      end,
+      "Jump to prev hunk",
+    },
+    ["<leader>h]"] = {
+      function()
+        package.loaded.gitsigns.next_hunk()
+      end,
+      "Jump to next hunk",
+    },
+
+    -- Actions
+    ["<leader>hp"] = {
+      function()
+        package.loaded.gitsigns.preview_hunk()
+      end,
+      "Preview hunk",
+    },
+    ["<leader>hr"] = {
+      function()
+        package.loaded.gitsigns.reset_hunk()
+      end,
+      "Reset hunk",
+    },
+    ["<leader>hs"] = {
+      function()
+        package.loaded.gitsigns.stage_hunk()
+      end,
+      "Stage hunk",
+    },
+    ["gB"] = {
+      function()
+        package.loaded.gitsigns.blame_line { full = true }
+      end,
+      "Hover-blame line",
+    },
+  },
+}
+
 M.disabled = {
   n = {
     -- general
@@ -80,6 +124,14 @@ M.disabled = {
     ["<A-i>"] = "",
     ["<A-h>"] = "",
     ["<A-v>"] = "",
+
+    -- gitsigns
+    ["]c"] = "",
+    ["[c"] = "",
+    ["<leader>rh"] = "",
+    ["<leader>ph"] = "",
+    ["<leader>gb"] = "",
+    ["<leader>td"] = "",
   },
 
   t = {


### PR DESCRIPTION
Notable changes in this PR:
- feat(gitsigns): remap hunk-wise keybindings to <leader>h based - make it a little easier to memorize keymappings of hunk-related actions
- feat(chadrc): update GitSignsChange highlight - make the yellowish color of "changed" hunks more perceptible