### PR TITLE
Show colorized undercurls for LSP diagnostics

### DIFF
--- a/lua/custom/chadrc.lua
+++ b/lua/custom/chadrc.lua
@@ -29,9 +29,29 @@ M.ui = {
     -- represented with a character, not a vertical bar like Add or Change
     -- so `bold = true` is important here to make the character more noticeable
     GitSignsDelete = {
-      fg = "#f38ba8",
+      fg = "#ed8796",
       bg = "NONE",
       bold = true,
+    },
+    DiagnosticUnderlineOk = {
+      sp = "#a6e3a1",
+      undercurl = true,
+    },
+    DiagnosticUnderlineInfo = {
+      sp = "#89b4fa",
+      undercurl = true,
+    },
+    DiagnosticUnderlineHint = {
+      sp = "#cba6f7",
+      undercurl = true,
+    },
+    DiagnosticUnderlineWarn = {
+      sp = "#f9e2af",
+      undercurl = true,
+    },
+    DiagnosticUnderlineError = {
+      sp = "#f38ba8",
+      undercurl = true,
     },
   },
   hl_override = {

--- a/lua/custom/chadrc.lua
+++ b/lua/custom/chadrc.lua
@@ -18,17 +18,11 @@ M.ui = {
       fg = "#8bc2f0",
       bg = "#474656",
     },
-
-    -- for both GitSignsChange and GitSignsChangedelete
-    GitSignsChange = {
+    GitSignsChange = { -- also for GitSignsChangedelete
       fg = "#eed49f",
       bg = "NONE",
     },
-
-    -- for both GitSignsDelete and GitSignsTopdelete, whose hunks are
-    -- represented with a character, not a vertical bar like Add or Change
-    -- so `bold = true` is important here to make the character more noticeable
-    GitSignsDelete = {
+    GitSignsDelete = { -- also for GitSignsTopdelete
       fg = "#ed8796",
       bg = "NONE",
       bold = true,


### PR DESCRIPTION
Following the tmux.conf support for colored undercurls in https://github.com/anhdau185/dotfiles/commit/f8877356e64e534494f84a138da8adc237f78709, this PR enables colorized undercurls for LSP diagnostics.